### PR TITLE
Fix initialization of usePolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed 
+- fix(usePolling): Use cleanDepedenciesCache instead of cleanCache in first invocation. Pass options to it and do not execute it in case provider is loading (#107)
 ### Removed
 
 ## [1.5.0] - 2020-11-16

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,7 +29,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/**/?(*.)+(spec|test).js?(x)"],
-  // testMatch: ["**/test/hocs.spec.js"],
+  // testMatch: ["**/test/usePolling.spec.js"],
 
   transform: {
     ".js$": "babel-jest",

--- a/src/usePolling.js
+++ b/src/usePolling.js
@@ -5,7 +5,7 @@ const pollingProviders = {};
 
 class PollingHandler {
   constructor(provider, intervalTime, options) {
-    provider.cleanCache();
+    provider.cleanDependenciesCache(options);
     this._options = options;
     this._provider = provider;
     this._id = provider.id;

--- a/src/usePolling.js
+++ b/src/usePolling.js
@@ -5,7 +5,9 @@ const pollingProviders = {};
 
 class PollingHandler {
   constructor(provider, intervalTime, options) {
-    provider.cleanDependenciesCache(options);
+    if (!provider.state.loading) {
+      provider.cleanDependenciesCache(options);
+    }
     this._options = options;
     this._provider = provider;
     this._id = provider.id;

--- a/test-e2e/cypress/integration/demo.js
+++ b/test-e2e/cypress/integration/demo.js
@@ -47,8 +47,40 @@ describe("Demo page", () => {
     it("should not be loading", () => {
       authors.shouldNotBeLoading();
     });
+  });
 
-    it("should display 5 results after adding a new book", () => {
+  describe("books column", () => {
+    it("should display 5 results", () => {
+      books.shouldDisplayItems(5);
+    });
+
+    it("should not be loading", () => {
+      books.shouldNotBeLoading();
+    });
+  });
+
+  describe("authors loaded column", () => {
+    it("should display 4 results", () => {
+      authorsLoaded.shouldDisplayItems(4);
+    });
+
+    it("should not be loading", () => {
+      authorsLoaded.shouldNotBeLoading();
+    });
+  });
+
+  describe("books loaded column", () => {
+    it("should display 5 results", () => {
+      booksLoaded.shouldDisplayItems(5);
+    });
+
+    it("should not be loading", () => {
+      booksLoaded.shouldNotBeLoading();
+    });
+  });
+
+  describe("when adding a new book", () => {
+    it("should display 5 results", () => {
       authors.add(NEW_AUTHOR);
       authors.shouldBeLoading();
       authorsLoaded.shouldNotBeLoading();

--- a/test/usePolling.spec.js
+++ b/test/usePolling.spec.js
@@ -76,6 +76,29 @@ describe("usePolling", () => {
     it("should clean provider cache each 500ms", async () => {
       render(<Component />);
       await wait(2200);
+      expect(provider.cleanCache.callCount).toEqual(4);
+    });
+  });
+
+  describe("when provider is not loading", () => {
+    beforeEach(async () => {
+      await provider.read();
+      BooksComponent = () => {
+        const books = useData(provider);
+        usePolling(provider, 500);
+        return <Books books={books} />;
+      };
+
+      Component = () => (
+        <ReduxProvider>
+          <BooksComponent />
+        </ReduxProvider>
+      );
+    });
+
+    it("should clean provider cache on initalization", async () => {
+      render(<Component />);
+      await wait(2200);
       expect(provider.cleanCache.callCount).toEqual(5);
     });
   });
@@ -99,7 +122,7 @@ describe("usePolling", () => {
     it("should use the lower polling interval", async () => {
       render(<Component />);
       await wait(2200);
-      expect(provider.cleanCache.callCount).toEqual(5);
+      expect(provider.cleanCache.callCount).toEqual(4);
     });
   });
 
@@ -134,7 +157,7 @@ describe("usePolling", () => {
       render(<Component />);
       const promise = wait(3100);
       await act(() => promise);
-      expect(provider.cleanCache.callCount).toEqual(4);
+      expect(provider.cleanCache.callCount).toEqual(3);
     });
   });
 

--- a/test/withPolling.spec.js
+++ b/test/withPolling.spec.js
@@ -87,7 +87,7 @@ describe("withPolling", () => {
     it("should clean provider cache each 500ms", async () => {
       render(<Component />);
       await wait(2200);
-      expect(provider.cleanCache.callCount).toEqual(5);
+      expect(provider.cleanCache.callCount).toEqual(4);
     });
   });
 
@@ -112,7 +112,7 @@ describe("withPolling", () => {
     it("should use the lower polling interval", async () => {
       render(<Component />);
       await wait(2200);
-      expect(provider.cleanCache.callCount).toEqual(5);
+      expect(provider.cleanCache.callCount).toEqual(4);
     });
   });
 
@@ -149,7 +149,7 @@ describe("withPolling", () => {
       render(<Component />);
       const promise = wait(3200);
       await act(() => promise);
-      expect(provider.cleanCache.callCount).toEqual(4);
+      expect(provider.cleanCache.callCount).toEqual(3);
     });
   });
 


### PR DESCRIPTION
### Fixed 
- fix(usePolling): Use cleanDepedenciesCache instead of cleanCache in first invocation. Pass options to it and do not execute it in case provider is loading
