### PR TITLE
Migrate to Github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: build
+on:
+  push:
+    branches:
+      - master
+      - release
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ["10.23.0", "12.19.0", "14.15.0", "15.2.0"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
+        id: extract-branch
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test unit
+        run: npm run test:unit
+      - name: Test E2E
+        run: npm run test:e2e
+        id: test-e2e
+      - name: Upload E2E tests screenshots
+        if: ${{ always() && steps.test-e2e.outcome == 'failure' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: e2e-screenshots-${{ matrix.node }}
+          path: test-e2e/cypress/screenshots
+          retention-days: 7
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage-${{ matrix.node }}
+          path: coverage
+          retention-days: 1
+  quality:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download test results
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-15.2.0
+          path: coverage
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: SonarCloud Scan
+        if: env.SONAR_TOKEN != ''
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test unit
         run: npm run test:unit
       - name: Test E2E
-        run: npm run test:e2e
+        run: npm run test:e2e:ci
         id: test-e2e
       - name: Upload E2E tests screenshots
         if: ${{ always() && steps.test-e2e.outcome == 'failure' }}

--- a/.github/workflows/publish-to-github.yml
+++ b/.github/workflows/publish-to-github.yml
@@ -1,4 +1,4 @@
-name: publish-to-github-registry
+name: publish-to-github
 on:
   release:
     types: [created]

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,18 @@
+name: publish-to-npm
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org/'
+    - run: npm ci
+    - run: npm run build
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-version: ~> 1.0
-import: data-provider/ci-cd-shared-config:.travis.yml@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- chore(ci): Migrate from Travis CI to github actions
+- chore(deps): Support all Node.js releases that have not passed their end date
 ### Changed
 ### Fixed 
 - fix(usePolling): Use cleanDepedenciesCache instead of cleanCache in first invocation. Pass options to it and do not execute it in case provider is loading (#107)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
-- chore(ci): Migrate from Travis CI to github actions
 - chore(deps): Support all Node.js releases that have not passed their end date
 ### Changed
+- chore(ci): Migrate from Travis CI to github actions
 ### Fixed 
 - fix(usePolling): Use cleanDepedenciesCache instead of cleanCache in first invocation. Pass options to it and do not execute it in case provider is loading (#107)
 ### Removed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status][travisci-image]][travisci-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Quality Gate][quality-gate-image]][quality-gate-url]
+[![Build status][build-image]][build-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Quality Gate][quality-gate-image]][quality-gate-url]
 
 [![NPM dependencies][npm-dependencies-image]][npm-dependencies-url] [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com) [![Last commit][last-commit-image]][last-commit-url] [![Last release][release-image]][release-url] 
 
@@ -536,8 +536,8 @@ Please read the [contributing guidelines](.github/CONTRIBUTING.md) and [code of 
 
 [coveralls-image]: https://coveralls.io/repos/github/data-provider/react/badge.svg
 [coveralls-url]: https://coveralls.io/github/data-provider/react
-[travisci-image]: https://travis-ci.com/data-provider/react.svg?branch=master
-[travisci-url]: https://travis-ci.com/data-provider/react
+[build-image]: https://github.com/data-provider/react/workflows/build/badge.svg?branch=master
+[build-url]: https://github.com/data-provider/react/actions?query=workflow%3Abuild+branch%3Amaster
 [last-commit-image]: https://img.shields.io/github/last-commit/data-provider/react.svg
 [last-commit-url]: https://github.com/data-provider/react/commits
 [license-image]: https://img.shields.io/npm/l/@data-provider/react.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -4246,19 +4246,6 @@
         "yaml": "^1.10.0"
       }
     },
-    "coveralls": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
-      "integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
-        "request": "^2.88.0"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -7536,12 +7523,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7812,12 +7793,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
-    },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -32,13 +32,9 @@
     "lint-staged": "lint-staged",
     "build": "rollup --config",
     "test": "jest",
-    "test:e2e": "cd test-e2e && npm run test:react-app",
+    "test:e2e": "npm run build && npm run test:e2e:install && npm run test:e2e",
     "test:e2e:install": "cd test-e2e && npm i && cd react-app && npm i",
-    "test:e2e:ci": "npm run build && npm run test:e2e:install && npm run test:e2e",
-    "test:unit:ci": "npm run test -- --coverage --ci --verbose=false --coverageReporters=lcov --coverageReporters=text-summary",
-    "test:ci": "npm run test:unit:ci && npm run test:e2e:ci",
-    "test:coverage": "npm run test:unit:ci",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "test:unit": "npm run test -- --coverage --ci --verbose=false --coverageReporters=lcov --coverageReporters=text-summary"
   },
   "dependencies": {
     "hoist-non-react-statics": "3.3.2"
@@ -63,7 +59,6 @@
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.1",
     "babel-polyfill": "6.26.0",
-    "coveralls": "3.0.9",
     "eslint": "7.12.1",
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-prettier": "3.1.4",
@@ -95,6 +90,6 @@
     }
   },
   "engines": {
-    "node": "12.x || 14.x || 15.x"
+    "node": "10.x || 12.x || 14.x || 15.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lint-staged": "lint-staged",
     "build": "rollup --config",
     "test": "jest",
-    "test:e2e": "npm run build && npm run test:e2e:install && npm run test:e2e",
+    "test:e2e": "cd test-e2e && npm run test:react-app",
+    "test:e2e:ci": "npm run build && npm run test:e2e:install && npm run test:e2e",
     "test:e2e:install": "cd test-e2e && npm i && cd react-app && npm i",
     "test:unit": "npm run test -- --coverage --ci --verbose=false --coverageReporters=lcov --coverageReporters=text-summary"
   },


### PR DESCRIPTION
### Added
- chore(deps): Support all Node.js releases that have not passed their end date

### Changed
- chore(ci): Migrate from Travis CI to github actions

### Fixed 
- fix(usePolling): Use cleanDepedenciesCache instead of cleanCache in first invocation. Pass options to it and do not execute it in case provider is loading (#107)
